### PR TITLE
Fixes for MLNX_OFED 4.2-1.2.0.0

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -6,5 +6,5 @@
   include_vars:
     file: "{{ rdma_type }}.yml"
 
-- include_tasks: redhat.yml
+- import_tasks: redhat.yml
   when: ansible_os_family == "RedHat" and rdma_enabled

--- a/tasks/redhat.yml
+++ b/tasks/redhat.yml
@@ -71,6 +71,23 @@
     - rdma_configure_single_port == False
     - reg_rdma_mellanox_devices.stdout == "1"
 
+
+- name: Do not fail by tying to load driver for non-existent mlx5_fpga
+  lineinfile:
+    path: /etc/infiniband/openib.conf
+    regexp: '^MLX5_FPGA_LOAD='
+    line: 'MLX5_FPGA_LOAD=no'
+    state: present
+  when: rdma_type == 'mlnx_ofed'
+
+- name: Do not fail by trying to load driver for mlx5
+  lineinfile:
+    path: /etc/infiniband/openib.conf
+    regexp: '^MLX5_LOAD='
+    line: 'MLX5_LOAD=no'
+    state: present
+  when: rdma_type == 'mlnx_ofed'
+
 ##
 
 - name: Manage the rdma service


### PR DESCRIPTION
Seems the latest MLNX_OFED insists on trying to load the mlx5 driver
modules even though hw isn't present on FGCI systems, and then
fails. This patch tells it to not try to load those drivers.

Further, it changes include_tasks to import_tasks. Otherwise it didn't
work when running from the admin node; maybe it worked when running
from ansible-pull-script.sh, but didn't try that.