### PR TITLE
Make MLNX_OFED init script work for chroot images

### DIFF
--- a/tasks/redhat.yml
+++ b/tasks/redhat.yml
@@ -130,3 +130,16 @@
   when:
     - ansible_connection == 'chroot'
     - rdma_manage_opensm
+
+# The MLNX_OFED init script won't work with bootstrap images since
+# kernel modules aren't symlinks and thus the script thinks the
+# modules don't belong to MLNX_OFED.  However, the script has a
+# variable FORCE that can be set to force it to ignore this check.
+- name: Fix /etc/init.d/openibd on chroots
+  lineinfile:
+    path: /etc/init.d/openibd
+    regexp: '^FORCE=0$'
+    line: 'FORCE=1'
+  when:
+    - ansible_connection == 'chroot'
+    - rdma_type == 'mlnx_ofed'


### PR DESCRIPTION
/etc/init.d/openibd does some checks to make sure that the kernel
modules it tries to load/unload belong to MLNX_OFED rpm's. This check
fails in an image environment where the initramfs is separate from the
image for the rest of the system. There is a variable FORCE that can
be set to override this check. So do that.