### PR TITLE
Support MLNX_OFED with the RPMS_UPSTREAM_LIBS

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -4,6 +4,7 @@
 # The type of RDMA setup used. Allowed values are
 # el - The out of the box IB/RDMA stack from RHEL
 # mlnx_ofed - Mellanox OFED
+# mlnx_ofed_upstream_libs - Mellanox OFED with RPMS_UPSTREAM_LIBS repo
 rdma_type: "el"
 
 # MLNX_OFED repo name

--- a/tasks/redhat.yml
+++ b/tasks/redhat.yml
@@ -85,7 +85,7 @@
     regexp: '^MLX5_FPGA_LOAD='
     line: 'MLX5_FPGA_LOAD=no'
     state: present
-  when: rdma_type == 'mlnx_ofed'
+  when: rdma_type == 'mlnx_ofed' or rdma_type == 'mlnx_ofed_upstream_libs'
 
 - name: Do not fail by trying to load driver for mlx5
   lineinfile:
@@ -93,7 +93,7 @@
     regexp: '^MLX5_LOAD='
     line: 'MLX5_LOAD=no'
     state: present
-  when: rdma_type == 'mlnx_ofed'
+  when: rdma_type == 'mlnx_ofed' or rdma_type == 'mlnx_ofed_upstream_libs'
 
 ##
 
@@ -149,4 +149,4 @@
     line: 'FORCE=1'
   when:
     - ansible_connection == 'chroot'
-    - rdma_type == 'mlnx_ofed'
+    - (rdma_type == 'mlnx_ofed' or rdma_type == 'mlnx_ofed_upstream_libs')

--- a/vars/mlnx_ofed_upstream_libs.yml
+++ b/vars/mlnx_ofed_upstream_libs.yml
@@ -1,0 +1,13 @@
+---
+# Variables for Mellanox OFED RDMA stack using the RPMS_UPSTREAM_LIBS repo
+
+rdma_core_packages:
+ - mlnx-ofed-kernel-only
+ - rdma-core
+ - libibverbs
+ - libibumad
+ - librdmacm
+
+rdma_service_name: "openibd"
+rdma_opensm_service: "opensm"
+rdma_opensm_partitions_conf_path: "/etc/rdma/partitions.conf"


### PR DESCRIPTION
MLNX_OFED provides two yum repositories, the full version with path
RPMS, and then the RPMS_UPSTREAM_LIBS version which uses the distro
userspace as much as possible, and only provides the enhanced(?)
kernel and userspace HW drivers.