### PR TITLE
Add opensm-libs to mlnx_ofed_upstream_libs

### DIFF
--- a/vars/mlnx_ofed_upstream_libs.yml
+++ b/vars/mlnx_ofed_upstream_libs.yml
@@ -9,6 +9,7 @@ rdma_core_packages:
  - librdmacm
  - ibutils2
  - infiniband-diags
+ - opensm-libs
 
 rdma_service_name: "openibd"
 rdma_opensm_service: "opensmd"


### PR DESCRIPTION
Some MPI libraries need libosmcomp.so.3 even though opensm itself is
not needed on a compute node.