### PR TITLE
Allow overriding rdma_core_packages installation. 

### DIFF
--- a/tasks/redhat.yml
+++ b/tasks/redhat.yml
@@ -8,9 +8,10 @@
     state: absent
   when: rdma_type == 'el'
 
+  # if rdma_core_packages is not defined use the ones from vars
 - name: install rdma
   package:
-    name: "{{ rdma_core_packages }}"
+    name: "{{ rdma_core_packages | default(role_rdma_core_packages) }}"
     state: present
 
 - name: install extra rdma packages

--- a/vars/mlnx_ofed.yml
+++ b/vars/mlnx_ofed.yml
@@ -1,7 +1,7 @@
 ---
 # Variables for Mellanox OFED RDMA stack
 
-rdma_core_packages:
+role_rdma_core_packages:
   - mlnx-ofed-kernel-only
   - libibverbs
   - libmlx4

--- a/vars/mlnx_ofed_upstream_libs.yml
+++ b/vars/mlnx_ofed_upstream_libs.yml
@@ -1,7 +1,7 @@
 ---
 # Variables for Mellanox OFED RDMA stack using the RPMS/UPSTREAM_LIBS repo
 
-rdma_core_packages:
+role_rdma_core_packages:
  - mlnx-ofed-kernel-only
  - rdma-core
  - libibverbs


### PR DESCRIPTION
Mellanox 4.9 has a bit different rpm package versions if using these LTS drivers. These modification allow overriding those from group_vars without breaking the default functionality.